### PR TITLE
feat: add new frame manager

### DIFF
--- a/packages/effekt/bundler.config.ts
+++ b/packages/effekt/bundler.config.ts
@@ -107,5 +107,23 @@ export default defineConfig({
         { find: /^@\/animation/, replacement: '../index.mts' },
       ]),
     },
+    // Frame
+    {
+      input: './src/frame/index.ts',
+      externals: [/^@\/config/, /^@\/shared/],
+      paths: resolvePaths([
+        { find: /^@\/config/, replacement: '../config/index.mjs' },
+        { find: /^@\/shared/, replacement: '../shared/index.mjs' },
+      ]),
+    },
+    {
+      input: './src/frame/driver.ts',
+      externals: ['./'],
+      paths: resolvePaths([{ find: './', replacement: './index.mjs' }]),
+    },
+    {
+      dts: './src/types/frame.ts',
+      output: './dist/frame/index.d.mts',
+    },
   ],
 })

--- a/packages/effekt/package.json
+++ b/packages/effekt/package.json
@@ -27,6 +27,10 @@
     "./interaction": {
       "types": "./dist/interaction/index.d.mts",
       "import": "./dist/interaction/index.mjs"
+    },
+    "./frame": {
+      "types": "./dist/frame/index.d.mts",
+      "import": "./dist/frame/index.mjs"
     }
   },
   "files": [

--- a/packages/effekt/src/config/index.ts
+++ b/packages/effekt/src/config/index.ts
@@ -5,6 +5,9 @@ export const config: EffektConfig = {
     autoplay: true,
     commitStyles: true,
   },
+  frame: {
+    fps: 60,
+  },
 }
 
 /**

--- a/packages/effekt/src/config/types/index.ts
+++ b/packages/effekt/src/config/types/index.ts
@@ -6,6 +6,12 @@ type ConfigAnimation = Omit<AnimationEffect, 'timeline'> &
 type ConfigFrame = { fps?: number }
 
 export interface EffektConfig {
+  /**
+   * Animation global options.
+   */
   animation?: ConfigAnimation
+  /**
+   * Frame global options.
+   */
   frame?: ConfigFrame
 }

--- a/packages/effekt/src/frame/driver.ts
+++ b/packages/effekt/src/frame/driver.ts
@@ -1,0 +1,11 @@
+import { frame } from './'
+import type { FrameDriver, FrameState } from './types'
+
+export const frameDriver: FrameDriver = (update) => {
+  const runFrame = ({ timestamp }: FrameState) => update(timestamp)
+
+  return {
+    start: () => frame.update(runFrame, { loop: true }),
+    stop: () => frame.cancel(runFrame),
+  }
+}

--- a/packages/effekt/src/frame/frame.ts
+++ b/packages/effekt/src/frame/frame.ts
@@ -1,0 +1,190 @@
+// Inspired by Frame, v0.1.1, MIT License, https://github.com/hypernym-studio/frame
+// Adapted to Effekt, v0.10.0, MIT License, https://github.com/effekt-labs/effekt
+
+import { config } from '@/config'
+import { isBrowser } from '@/shared'
+import type {
+  Phase,
+  PhaseIDs,
+  PhaseCallback,
+  PhaseScheduleOptions,
+  FrameState,
+  Frame,
+} from './types'
+
+const defaultState = (): FrameState => ({
+  delta: 0.0,
+  timestamp: 0.0,
+  isRunning: false,
+  isPaused: false,
+})
+
+export function createFrame(): Frame {
+  let fps: number | undefined = config.frame?.fps
+
+  const framePhases: PhaseIDs[] = ['read', 'update', 'render']
+  const phases = {} as Record<PhaseIDs, Phase>
+  const loops = new Set<PhaseCallback>()
+
+  let tickerId: number | null = null
+  let shouldRunTicker: boolean = false
+  let isPaused: boolean = false
+
+  const frameInterval: number = 1000 / (fps || 60)
+  let lastFrameTime: number = 0
+  let lastPauseTime: number | null = null
+  let totalPausedTime: number = 0
+  let useFrameInterval: boolean = true
+
+  let state: FrameState = defaultState()
+
+  const phase = (callback: (id: Phase) => void): void =>
+    framePhases.forEach((id) => callback(phases[id]))
+
+  const createPhase = (): Phase => {
+    let thisFrame = new Set<PhaseCallback>()
+    let nextFrame = new Set<PhaseCallback>()
+
+    let isRunning: boolean = false
+    let flushNextFrame: boolean = false
+
+    const runPhaseCallback = (callback: PhaseCallback): void => {
+      if (loops.has(callback)) phase.schedule(callback)
+      callback(state)
+    }
+
+    const swapFrames = () => ([thisFrame, nextFrame] = [nextFrame, thisFrame])
+
+    const phase: Phase = {
+      schedule: (
+        callback: PhaseCallback,
+        { loop, schedule = true }: PhaseScheduleOptions = {},
+      ): PhaseCallback => {
+        const queue = isRunning && !schedule ? thisFrame : nextFrame
+        if (loop) loops.add(callback)
+        if (!queue.has(callback)) queue.add(callback)
+        return callback
+      },
+      run: (state: FrameState): void => {
+        if (isRunning) {
+          flushNextFrame = true
+          return
+        }
+
+        isRunning = true
+
+        swapFrames()
+        thisFrame.forEach(runPhaseCallback)
+        thisFrame.clear()
+
+        isRunning = false
+
+        if (flushNextFrame) {
+          flushNextFrame = false
+          phase.run(state)
+        }
+      },
+      cancel: (callback: PhaseCallback): void => {
+        nextFrame.delete(callback)
+        loops.delete(callback)
+      },
+      clear: (): void => {
+        thisFrame.clear()
+        nextFrame.clear()
+      },
+    }
+    return phase
+  }
+
+  const runTicker = (): void => {
+    if (isBrowser) tickerId = requestAnimationFrame(runFrame)
+  }
+
+  const cancelTicker = (): void => {
+    if (isBrowser && tickerId) {
+      cancelAnimationFrame(tickerId)
+      tickerId = null
+    }
+  }
+
+  const runFrame = (timestamp: number): void => {
+    const time = timestamp - totalPausedTime
+    shouldRunTicker = loops.size > 0
+
+    if (fps) {
+      const delta = time - lastFrameTime
+      if (delta < frameInterval) {
+        runTicker()
+        return
+      }
+      lastFrameTime = time - (delta % frameInterval)
+    }
+
+    state.delta = useFrameInterval ? frameInterval : time - state.timestamp
+    state.timestamp = time
+    state.isPaused = isPaused
+
+    state.isRunning = true
+
+    phase((id) => id.run(state))
+
+    state.isRunning = false
+
+    if (shouldRunTicker && !isPaused) {
+      useFrameInterval = false
+      runTicker()
+    } else cancelTicker()
+  }
+
+  const frame: Frame = {
+    play: (): void => {
+      if (isPaused && shouldRunTicker) {
+        isPaused = false
+        const now = performance.now()
+        if (lastPauseTime) {
+          totalPausedTime += now - lastPauseTime
+          lastPauseTime = null
+        }
+        lastFrameTime = now - totalPausedTime
+        state.timestamp = lastFrameTime
+        runTicker()
+      }
+    },
+    pause: (): void => {
+      if (!isPaused) {
+        isPaused = true
+        cancelTicker()
+        lastPauseTime = performance.now()
+      }
+    },
+    cancel: (callback: PhaseCallback): void => {
+      phase((id) => id.cancel(callback))
+    },
+    clear: (): void => {
+      state = defaultState()
+      phase((id) => id.clear())
+      cancelTicker()
+      shouldRunTicker = false
+    },
+    get state(): Readonly<FrameState> {
+      return state
+    },
+  } as Frame
+
+  framePhases.forEach((id) => {
+    phases[id] = createPhase()
+    frame[id] = (
+      callback: PhaseCallback,
+      options: PhaseScheduleOptions = {},
+    ) => {
+      if (!shouldRunTicker) {
+        useFrameInterval = true
+        lastFrameTime = performance.now()
+        runTicker()
+      }
+      return phases[id].schedule(callback, options)
+    }
+  })
+
+  return frame
+}

--- a/packages/effekt/src/frame/index.ts
+++ b/packages/effekt/src/frame/index.ts
@@ -1,0 +1,32 @@
+import { createFrame } from './frame'
+
+/**
+ * Creates a universal `frame` manager.
+ *
+ * **Frame** is designed to manage and execute processes in different phases of a frame-based loop,
+ * typically used for timed operations, making it ideal for game loops, animations or periodic updates.
+ *
+ * @example
+ *
+ * ```ts
+ * import { frame } from 'effekt/frame'
+ *
+ * let index = 0
+ *
+ * // Adds a custom callback to the `update` phase and enables looping
+ * const onUpdate = frame.update(
+ *   (state) => {
+ *     console.log('Update Phase Loop')
+ *
+ *     index++
+ *
+ *     if (index > 100) {
+ *       frame.cancel(onUpdate)
+ *       console.log('Update Phase Loop: Done!', state)
+ *     }
+ *   },
+ *   { loop: true },
+ * )
+ * ```
+ */
+export const frame = createFrame()

--- a/packages/effekt/src/frame/types/driver.ts
+++ b/packages/effekt/src/frame/types/driver.ts
@@ -1,0 +1,8 @@
+export interface FrameDriverControls {
+  start: () => void
+  stop: () => void
+}
+
+export type FrameDriverUpdate = (timestamp: number) => void
+
+export type FrameDriver = (update: FrameDriverUpdate) => FrameDriverControls

--- a/packages/effekt/src/frame/types/frame.ts
+++ b/packages/effekt/src/frame/types/frame.ts
@@ -1,0 +1,39 @@
+export type PhaseIDs = 'read' | 'update' | 'render'
+
+export type PhaseCallback = (state: FrameState) => void
+
+export interface PhaseScheduleOptions {
+  loop?: boolean
+  schedule?: boolean
+}
+
+export type PhaseSchedule = (
+  callback: PhaseCallback,
+  options?: PhaseScheduleOptions,
+) => PhaseCallback
+
+export interface Phase {
+  schedule: PhaseSchedule
+  run: (state: FrameState) => void
+  cancel: (callback: PhaseCallback) => void
+  clear: () => void
+}
+
+export interface FrameState {
+  delta: number
+  timestamp: number
+  isRunning: boolean
+  isPaused: boolean
+}
+
+export type FramePhases = {
+  [K in PhaseIDs]: PhaseSchedule
+}
+
+export type Frame = {
+  play: () => void
+  pause: () => void
+  cancel: (callback: PhaseCallback) => void
+  clear: () => void
+  get state(): Readonly<FrameState>
+} & FramePhases

--- a/packages/effekt/src/frame/types/index.ts
+++ b/packages/effekt/src/frame/types/index.ts
@@ -1,0 +1,2 @@
+export * from './frame'
+export * from './driver'

--- a/packages/effekt/src/types/frame.ts
+++ b/packages/effekt/src/types/frame.ts
@@ -1,0 +1,6 @@
+// Exports types intended only for the `frame` package
+// import type { ... } from 'effekt/frame'
+
+export * from '@/frame/types'
+export * from '@/frame/driver'
+export * from '@/frame'


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Request Description

Adds a new `frame` manager.

This will be available as a separate subpath of `Effekt's` modular system.

This way you have the choice to import only what you really need.

Also, its a very lightweight (size: `~1.33 KB` or `~755 B` minified) solution as well as others modules.

### frame

Creates a universal `frame` manager.

**Frame** is designed to manage and execute processes in different phases of a frame-based loop, typically used for timed operations, making it ideal for game loops, animations or periodic updates.

```ts
import { frame } from 'effekt/frame'

let index = 0

// Adds a custom callback to the `update` phase and enables looping
const onUpdate = frame.update(
  (state) => {
    console.log('Update Phase Loop')

    index++

    if (index > 100) {
      frame.cancel(onUpdate)
      console.log('Update Phase Loop: Done!', state)
    }
  },
  { loop: true },
)

```
