### PR TITLE
feat: add new interaction watch function

### DIFF
--- a/packages/effekt/bundler.config.ts
+++ b/packages/effekt/bundler.config.ts
@@ -90,23 +90,6 @@ export default defineConfig({
         { find: /^@\/animation/, replacement: '../index.mts' },
       ]),
     },
-    // Interaction
-    {
-      input: './src/interaction/index.ts',
-      externals: [/^@\/shared/, /^@\/utils/],
-      paths: resolvePaths([
-        { find: /^@\/shared/, replacement: '../shared/index.mjs' },
-        { find: /^@\/utils/, replacement: '../utils/index.mjs' },
-      ]),
-    },
-    {
-      dts: './src/types/interaction.ts',
-      output: './dist/interaction/index.d.mts',
-      externals: [/^@\/animation/],
-      paths: resolvePaths([
-        { find: /^@\/animation/, replacement: '../index.mts' },
-      ]),
-    },
     // Frame
     {
       input: './src/frame/index.ts',
@@ -124,6 +107,26 @@ export default defineConfig({
     {
       dts: './src/types/frame.ts',
       output: './dist/frame/index.d.mts',
+    },
+    // Interaction
+    {
+      input: './src/interaction/index.ts',
+      externals: [/^@\/shared/, /^@\/utils/, /^@\/frame\/driver/],
+      paths: resolvePaths([
+        { find: /^@\/shared/, replacement: '../shared/index.mjs' },
+        { find: /^@\/utils/, replacement: '../utils/index.mjs' },
+        { find: /^@\/frame\/driver/, replacement: '../frame/driver.mjs' },
+      ]),
+    },
+    {
+      dts: './src/types/interaction.ts',
+      output: './dist/interaction/index.d.mts',
+      externals: [/^@\/shared/, /^@\/animation/, /^@\/frame/],
+      paths: resolvePaths([
+        { find: /^@\/shared/, replacement: '../index.mts' },
+        { find: /^@\/animation/, replacement: '../index.mts' },
+        { find: /^@\/frame/, replacement: '../frame/index.mts' },
+      ]),
     },
   ],
 })

--- a/packages/effekt/package.json
+++ b/packages/effekt/package.json
@@ -24,13 +24,13 @@
       "types": "./dist/sequence/index.d.mts",
       "import": "./dist/sequence/index.mjs"
     },
-    "./interaction": {
-      "types": "./dist/interaction/index.d.mts",
-      "import": "./dist/interaction/index.mjs"
-    },
     "./frame": {
       "types": "./dist/frame/index.d.mts",
       "import": "./dist/frame/index.mjs"
+    },
+    "./interaction": {
+      "types": "./dist/interaction/index.d.mts",
+      "import": "./dist/interaction/index.mjs"
     }
   },
   "files": [

--- a/packages/effekt/src/interaction/in-view.ts
+++ b/packages/effekt/src/interaction/in-view.ts
@@ -1,7 +1,7 @@
 import { getElements } from '@/utils'
 import { noop, isFunction } from '@/shared'
 import type { AnimationTargets } from '@/animation/types'
-import type { InViewOptions, InViewCallback } from './types'
+import type { InViewCallback, InViewOptions, InView } from './types'
 
 /**
  * Triggers a callback when the specified elements enter and leave the viewport.
@@ -34,7 +34,7 @@ import type { InViewOptions, InViewCallback } from './types'
  * })
  * ```
  *
- * The function returns a cleanup function that can be invoked to stop observing the elements when needed,
+ * Also, inView returns a cleanup function that can be invoked to stop observing the elements when needed,
  * such as when the component is destroyed or when the observer is no longer required.
  *
  * @example
@@ -43,7 +43,6 @@ import type { InViewOptions, InViewCallback } from './types'
  * const stopInView = inView('.el', ({ target }) => {
  *   animate(target, { opacity: [0, 1] })
  * })
- *
  * // Stops viewport detection
  * stopInView()
  * ```
@@ -52,7 +51,7 @@ export function inView(
   targets: AnimationTargets,
   onEnter: (entry: IntersectionObserverEntry) => void | InViewCallback,
   options: InViewOptions = {},
-): VoidFunction {
+): InView {
   const { root, margin, threshold } = options
 
   const els = getElements(targets)

--- a/packages/effekt/src/interaction/index.ts
+++ b/packages/effekt/src/interaction/index.ts
@@ -1,1 +1,2 @@
 export * from './in-view'
+export * from './watch'

--- a/packages/effekt/src/interaction/types/in-view.ts
+++ b/packages/effekt/src/interaction/types/in-view.ts
@@ -1,5 +1,7 @@
 export type InViewCallback = (entry: IntersectionObserverEntry) => void
 
+export type InView = () => void
+
 type RootMarginString = `${number}${'px' | '%'}`
 export type RootMargin =
   | RootMarginString

--- a/packages/effekt/src/interaction/types/index.ts
+++ b/packages/effekt/src/interaction/types/index.ts
@@ -1,1 +1,2 @@
 export * from './in-view'
+export * from './watch'

--- a/packages/effekt/src/interaction/types/watch.ts
+++ b/packages/effekt/src/interaction/types/watch.ts
@@ -1,0 +1,27 @@
+import type { EasingFunction } from '@/shared/types'
+import type { FrameDriver } from '@/frame/types'
+
+export type WatchCallback = (progress: number) => void
+
+export type Watch = () => void
+
+export interface WatchOptions {
+  /**
+   * Specifies whether the watcher should automatically stop tracking after the animation ends.
+   *
+   * @default true
+   */
+  autostop?: boolean
+  /**
+   * Specifies optional easing function that transforms the raw, linear progress value into a more dynamic, non-linear custom effect.
+   *
+   * @default (p: number) => p
+   */
+  ease?: EasingFunction
+  /**
+   * Specifies a custom frame driver that controls the timing and scheduling of the animation updates.
+   *
+   * @default frameDriver
+   */
+  driver?: FrameDriver
+}

--- a/packages/effekt/src/interaction/watch.ts
+++ b/packages/effekt/src/interaction/watch.ts
@@ -1,0 +1,114 @@
+import { isBrowser, noop } from '@/shared'
+import { frameDriver } from '@/frame/driver'
+import type { Animation } from '@/animation/types'
+import type { WatchCallback, WatchOptions, Watch } from './types'
+
+/**
+ * Syncs animation progress to an external system.
+ *
+ * Watches the internal state and triggers a custom callback whenever the progress value changes.
+ *
+ * Watcher is lazy by design, meaning it is only called when there is a difference in progress since the last check.
+ * This helps avoid unnecessary calculations and maintains efficient updating.
+ *
+ * Use Cases:
+ *
+ * - Animations: Runs frame-by-frame progress calls to create custom animation behaviors.
+ * - UI Sync: Updates the state of UI elements (like intros, progress bars or loaders) in real-time as the animation progresses.
+ * - Event Triggering: Executes effects exactly when the animation reaches certain progress thresholds.
+ *
+ * @example
+ *
+ * ```ts
+ * import { animate } from 'effekt'
+ * import { watch } from 'effekt/interaction'
+ *
+ * const animation = animate('.el', { opacity: [0, 1] })
+ *
+ * watch(animation, (progress) => {
+ *   // Called every time the animation is updated
+ *   console.log(progress)
+ * })
+ * ```
+ *
+ * By default, watching will automatically stop when the animation ends.
+ *
+ * In addition to the auto-stop feature, watch returns a cleanup function that allows you to manually stop the process at any point,
+ * giving you complete control over the watcher's lifecycle.
+ *
+ * @example
+ *
+ * ```ts
+ * const stopWatch = watch(animation, (progress) => {
+ *   console.log(progress)
+ * })
+ * // Stops watching
+ * stopWatch()
+ * ```
+ *
+ * Watch function is actually driven by the main `frame` manager.
+ *
+ * In certain scenarios, it may be necessary to synchronize animations with another system or external source.
+ *
+ * Watch supports setting up a custom external frame `driver` that allows seamless integration.
+ *
+ * @example
+ *
+ * ```ts
+ * import type { FrameDriver } from 'effekt/frame'
+ *
+ * const customDriver: FrameDriver = (update) => {
+ *   let rafId: number
+ *   let now = performance.now()
+ *
+ *   const runFrame = (timestamp: number) => {
+ *     rafId = requestAnimationFrame(runFrame)
+ *     const delta = timestamp - now
+ *     now = timestamp
+ *     update(delta)
+ *   }
+ *
+ *   return {
+ *     start: () => (rafId = requestAnimationFrame(runFrame)),
+ *     stop: () => cancelAnimationFrame(rafId),
+ *   }
+ * }
+ *
+ * watch(animation, (progress) => console.log(progress), { driver: customDriver })
+ * ```
+ */
+export function watch(
+  animation: Animation,
+  callback: WatchCallback,
+  options: WatchOptions = {},
+): Watch {
+  if (!isBrowser) return noop
+
+  const {
+    driver = frameDriver,
+    ease = (p: number) => p,
+    autostop = true,
+  } = options
+
+  let progress: number
+
+  const onFrame = (): void => {
+    let newProgress = animation.progress
+
+    if (animation.isCompleted) {
+      newProgress = 1
+      if (autostop) frame.stop()
+    }
+
+    if (newProgress !== progress) {
+      progress = newProgress
+      callback(ease(progress))
+    }
+  }
+
+  const frame = driver(onFrame)
+
+  frame.start()
+
+  return () => frame.stop()
+}


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Request Description

Adds a new interaction `watch` function.

Also, its a very lightweight (size: `~340 B` minified or `~250 B` gzip) solution as well as others modules.

### watch

Syncs animation progress to an external system.

Watches the internal state and triggers a custom callback whenever the progress value changes.

Watcher is lazy by design, meaning it is only called when there is a difference in progress since the last check. This helps avoid unnecessary calculations and maintains efficient updating.

#### Use Cases:
 
- Animations: Runs frame-by-frame progress calls to create custom animation behaviors.
- UI Sync: Updates the state of UI elements (like intros, progress bars or loaders) in real-time as the animation progresses.
- Event Triggering: Executes effects exactly when the animation reaches certain progress thresholds.

```ts
import { animate } from 'effekt'
import { watch } from 'effekt/interaction'

const animation = animate('.el', { opacity: [0, 1] })

watch(animation, (progress) => {
  // Called every time the animation is updated
  console.log(progress)
})
```

By default, watching will automatically stop when the animation ends.

In addition to the auto-stop feature, watch returns a cleanup function that allows you to manually stop the process at any point, giving you complete control over the watcher's lifecycle.

```ts
const stopWatch = watch(animation, (progress) => {
  console.log(progress)
})
// Stops watching
stopWatch()
```

Watch function is actually driven by the main `frame` manager.

In certain scenarios, it may be necessary to synchronize animations with another system or external source.

Watch supports setting up a custom external frame `driver` that allows seamless integration.

```ts
import type { FrameDriver } from 'effekt/frame'

const customDriver: FrameDriver = (update) => {
  let rafId: number
  let now = performance.now()

  const runFrame = (timestamp: number) => {
    rafId = requestAnimationFrame(runFrame)
    const delta = timestamp - now
    now = timestamp
    update(delta)
  }

  return {
    start: () => (rafId = requestAnimationFrame(runFrame)),
    stop: () => cancelAnimationFrame(rafId),
  }
}

watch(animation, (progress) => console.log(progress), { driver: customDriver })
```

