### PR TITLE
feat: add setter to animation progress

### DIFF
--- a/packages/effekt/src/animation/types/animation.ts
+++ b/packages/effekt/src/animation/types/animation.ts
@@ -19,6 +19,7 @@ export interface Animation {
   get timeline(): globalThis.AnimationTimeline | null
   set timeline(t: globalThis.AnimationTimeline | null)
   get playState(): Readonly<globalThis.AnimationPlayState>
-  get progress(): Readonly<number>
+  get progress(): number
+  set progress(t: number)
   get isCompleted(): Readonly<boolean>
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

Adds `setter` to `animation.progress`.

```ts
import { animate } from 'effekt'

const animation = animate('.el', {
  autoplay: false,
  x: [0, 600]
})

// progress can be a value from `0` to `1`
animation.progress = 0.33
```