### PR TITLE
feat(frame): add new activeLoops getter

### DIFF
--- a/packages/effekt/src/frame/types/frame.ts
+++ b/packages/effekt/src/frame/types/frame.ts
@@ -36,4 +36,5 @@ export type Frame = {
   cancel: (callback: PhaseCallback) => void
   clear: () => void
   get state(): Readonly<FrameState>
+  get activeLoops(): Readonly<number>
 } & FramePhases


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types
- [x] Documentation

## Request Description

Improves Frame's loop storage performance via `WeakSet`, and also exposes the `activeLoops` getter publicly.

### activeLoops

Provides a read-only number of active frame loops at any given point.

Useful for debugging and monitoring or for dynamic actions.

```ts
import { frame } from 'effekt/frame'

console.log(frame.activeLoops)
```